### PR TITLE
Improve results layout and tabs styling

### DIFF
--- a/assets/wcls.css
+++ b/assets/wcls.css
@@ -25,7 +25,8 @@
 .wcls-results {
   position: absolute;
   top: calc(100% + 6px);
-  left: 0; right: 0;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 10000;
   display: none;
   background: #fff;
@@ -35,31 +36,40 @@
   overflow: hidden;
   max-height: 420px;
   overflow-y: auto;
+  width: min(600px, 100vw - 40px);
 }
 .wcls-results.wcls-show { display: block; }
 
 /* Tabs */
 .wcls-tabs {
   display: flex;
-  gap: 4px;
-  padding: 8px;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 10px;
   border-bottom: 1px solid #f1f1f1;
   background: #fafafa;
-  position: sticky; top: 0;
+  position: sticky;
+  top: 0;
 }
 .wcls-tab {
   appearance: none;
-  background: transparent;
-  border: 1px solid transparent;
+  background: #f2f2f2;
+  border: 1px solid #e1e1e1;
   border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 13px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
   cursor: pointer;
+  transition: background-color .15s, color .15s;
+}
+.wcls-tab:hover {
+  background: #e9e9e9;
 }
 .wcls-tab.is-active {
   background: #fff;
-  border-color: #e1e1e1;
-  box-shadow: 0 1px 0 rgba(0,0,0,.02);
+  color: #0073aa;
+  border-color: #d1d1d1;
+  box-shadow: 0 1px 0 rgba(0,0,0,.02), inset 0 -2px 0 #0073aa;
 }
 
 .wcls-panels { padding: 6px 6px 10px; }


### PR DESCRIPTION
## Summary
- center the search results container and allow it to grow wider for easier reading
- restyle results tabs with clearer background, hover, and active states

## Testing
- `php -l woo-live-ajax-search.php`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a870e0db048326ba298d2ce4faf908